### PR TITLE
[CHANGE] Don't ask for an email when `REGISTRATION_VERIFY_EMAIL` is set to `False`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Don't ask for an email when `REGISTRATION_VERIFY_EMAIL` is set to `False`
+
 ## [3.4.0] - 2024-12-10
 
 ### Changed

--- a/testauth/settings/local.py
+++ b/testauth/settings/local.py
@@ -108,7 +108,7 @@ ESI_SSO_CALLBACK_URL = "http://localhost:8000"
 # Set the default from email to something like 'noreply@example.com'
 # Email validation can be turned off by uncommenting the line below.
 # This can break some services.
-REGISTRATION_VERIFY_EMAIL = False
+# REGISTRATION_VERIFY_EMAIL = False
 EMAIL_HOST = ""
 EMAIL_PORT = 587
 EMAIL_HOST_USER = ""

--- a/tnnt_templates/context_processors.py
+++ b/tnnt_templates/context_processors.py
@@ -3,6 +3,7 @@ TN-NT Templates content processor
 """
 
 # Django
+from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
 
 # AA Templates: Terra Nanotech
@@ -18,7 +19,10 @@ def tnnt_settings(request: WSGIRequest) -> dict:  # pylint: disable=unused-argum
 
     # AA logo
     return_value = {
-        "TNNT_TEMPLATE_AA_LOGO": "/static/allianceauth/images/auth-logo.svg"
+        "TNNT_TEMPLATE_AA_LOGO": "/static/allianceauth/images/auth-logo.svg",
+        "REGISTRATION_VERIFY_EMAIL": getattr(
+            settings, "REGISTRATION_VERIFY_EMAIL", True
+        ),
     }
 
     # entity ID

--- a/tnnt_templates/templates/public/register.html
+++ b/tnnt_templates/templates/public/register.html
@@ -1,0 +1,64 @@
+{% extends 'public/base.html' %}
+
+{% load django_bootstrap5 %}
+{% load i18n %}
+
+{% block page_title %}{% translate "Registration" %}{% endblock %}
+
+{% block extra_include %}
+    {% include 'bundles/bootstrap-css-bs5.html' %}
+    {% include 'bundles/fontawesome.html' %}
+    {% include 'bundles/bootstrap-js-bs5.html' %}
+    {% include 'bundles/jquery-js.html' %}
+{% endblock %}
+
+{% block content %}
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card card-login border-secondary p-3">
+                <div class="card-body">
+                    <form method="POST">
+                        {% csrf_token %}
+
+                        {% if REGISTRATION_VERIFY_EMAIL %}
+                            {% bootstrap_form form %}
+
+                            <button class="btn btn-primary btn-block" type="submit">
+                                {% translate "Register" %}
+                            </button>
+                        {% else %}
+                            <input
+                                type="hidden"
+                                name="email"
+                                maxlength="254"
+                                class=" form-control"
+                                required=""
+                                id="id_email"
+                                value="{{request.session.registration_uid}}@{{request.get_host}}"
+                                readonly
+                            >
+
+                            <p class="text-center mb-0">
+                                {% translate "Redirecting to the dashboard …" %}
+                            </p>
+
+                            <button class="d-none" type="submit">
+                                {% translate "Register" %}
+                            </button>
+
+                            <script>
+                                $(() => {
+                                    $("button[type='submit']").click();
+                                });
+                            </script>
+                        {% endif %}
+                    </form>
+
+                    {% if REGISTRATION_VERIFY_EMAIL %}
+                        {% include 'public/lang_select.html' %}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/tnnt_templates/tests/test_context_processors.py
+++ b/tnnt_templates/tests/test_context_processors.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 # Django
 from django.http import HttpRequest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 # AA Templates: Terra Nanotech
 from tnnt_templates.app_settings import AppSettings
@@ -199,16 +199,12 @@ class ContextProcessorsTests(TestCase):
 
         result = tnnt_settings(request=self.request)
 
-        self.assertEqual(first=result["REGISTRATION_VERIFY_EMAIL"], second=True)
+        self.assertTrue(result["REGISTRATION_VERIFY_EMAIL"])
 
-    @patch.object(
-        target=AppSettings,
-        attribute="REGISTRATION_VERIFY_EMAIL",
-        new=False,
-    )
+    @override_settings(REGISTRATION_VERIFY_EMAIL=False)
     def test_should_return_email_verification_as_false(self):
         """
-        Test the default value of REGISTRATION_VERIFY_EMAIL
+        Test the custom value of REGISTRATION_VERIFY_EMAIL
 
         :return:
         :rtype:
@@ -216,4 +212,4 @@ class ContextProcessorsTests(TestCase):
 
         result = tnnt_settings(request=self.request)
 
-        self.assertEqual(first=result["REGISTRATION_VERIFY_EMAIL"], second=False)
+        self.assertFalse(result["REGISTRATION_VERIFY_EMAIL"])

--- a/tnnt_templates/tests/test_context_processors.py
+++ b/tnnt_templates/tests/test_context_processors.py
@@ -188,3 +188,32 @@ class ContextProcessorsTests(TestCase):
             first=result["TNNT_TEMPLATE_AA_LOGO"],
             second="/static/allianceauth/images/auth-logo.svg",
         )
+
+    def test_should_return_email_verification_as_true(self):
+        """
+        Test the default value of REGISTRATION_VERIFY_EMAIL
+
+        :return:
+        :rtype:
+        """
+
+        result = tnnt_settings(request=self.request)
+
+        self.assertEqual(first=result["REGISTRATION_VERIFY_EMAIL"], second=True)
+
+    @patch.object(
+        target=AppSettings,
+        attribute="REGISTRATION_VERIFY_EMAIL",
+        new=False,
+    )
+    def test_should_return_email_verification_as_false(self):
+        """
+        Test the default value of REGISTRATION_VERIFY_EMAIL
+
+        :return:
+        :rtype:
+        """
+
+        result = tnnt_settings(request=self.request)
+
+        self.assertEqual(first=result["REGISTRATION_VERIFY_EMAIL"], second=False)


### PR DESCRIPTION
### Changed

- Don't ask for an email when `REGISTRATION_VERIFY_EMAIL` is set to `False`

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
