### PR TITLE
[ADD] Management command to anonymize all user's email addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ Section Order:
 ### Security
 -->
 
+### Added
+
+- Management command to anonymize all user's email addresses in the database
+  ```shell
+  python manage.py tnnt_anonymize_emails
+  ```
+  This will replace each user's email address with `user_id@domain.tld` (e.g. `371@my.auth.com`)
+
 ## [3.4.1] - 2024-12-17
 
 ### Changed

--- a/tnnt_templates/management/commands/tnnt_anonymize_emails.py
+++ b/tnnt_templates/management/commands/tnnt_anonymize_emails.py
@@ -1,0 +1,103 @@
+"""
+Management command to anonymize all email addresses in the database.
+"""
+
+# Standard Library
+from urllib.parse import urlparse
+
+# Django
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+# Alliance Auth
+from allianceauth.authentication.models import User
+
+
+def get_input(text) -> str:
+    """
+    Wrapped input to enable import
+
+    :param text:
+    :type text:
+    :return:
+    :rtype:
+    """
+
+    return input(text)
+
+
+class Command(BaseCommand):
+    """
+    Anonymize all email addresses in the database.
+    """
+
+    help = "This command will anonymize each user's email address in the database."
+
+    def add_arguments(self, parser):
+        """
+        Add argument to parser
+        :param parser:
+        :type parser:
+        :return:
+        :rtype:
+        """
+
+        parser.add_argument(
+            "--noinput",
+            "--no-input",
+            action="store_true",
+            help="Do NOT prompt the user for input of any kind.",
+        )
+
+    def _anonymize_user_emails(self) -> None:
+        """
+        Start the anonymization
+
+        :return:
+        :rtype:
+        """
+
+        self.stdout.write(msg="Anonymizing email addresses …")
+
+        site_fqdn = urlparse(settings.SITE_URL).netloc
+
+        # Get all users and filter those who need anonymization
+        users = User.objects.exclude(email="").exclude(email__endswith=f"@{site_fqdn}")
+
+        # Loop through filtered users and anonymize email address
+        for user in users:
+            self.stdout.write(f"Anonymizing email address for {user.username} …")
+
+            user.email = f"{user.pk}@{site_fqdn}"
+            user.save()
+
+        self.stdout.write(msg=self.style.SUCCESS("Anonymization complete!"))
+
+    def handle(self, *args, **options):  # pylint: disable=unused-argument
+        """
+        Ask before running …
+
+        :param args:
+        :type args:
+        :param options:
+        :type options:
+        :return:
+        :rtype:
+        """
+
+        self.stdout.write(
+            msg=self.style.SUCCESS(
+                "This will anonymize each user's email address in the database."
+            )
+        )
+
+        if not options["noinput"]:
+            user_input = get_input(text="Are you sure you want to proceed? (yes/no) ")
+        else:
+            user_input = "yes"
+
+        if user_input.lower() == "yes":
+            self.stdout.write(msg="Starting, Please stand by …")
+            self._anonymize_user_emails()
+        else:
+            self.stdout.write(msg=self.style.WARNING("Aborted."))

--- a/tnnt_templates/tests/test_command_anonymize_emails.py
+++ b/tnnt_templates/tests/test_command_anonymize_emails.py
@@ -1,0 +1,46 @@
+# Standard Library
+from io import StringIO
+
+# Django
+from django.test import TestCase, override_settings
+
+# Alliance Auth (External Libs)
+from app_utils.testing import create_fake_user
+
+
+class ManagementCommandAnonymizeEmailsTests(TestCase):
+    def call_command(self, *args, **kwargs):
+        # Django
+        from django.core.management import call_command
+
+        call_command(
+            "tnnt_anonymize_emails",
+            *args,
+            stdout=StringIO(),
+            stderr=StringIO(),
+            **kwargs,
+        )
+
+    def setUp(self):
+        """
+        Setup tests
+        """
+
+        self.user = create_fake_user(character_id=2001, character_name="Wesley Crusher")
+
+        self.user.email = "wesley.crusher@enterprise.space"
+        self.user.save()
+
+    @override_settings(SITE_URL="https://auth.testserver.net")
+    def test_command_anonymize_emails(self):
+        """
+        Test command
+        """
+
+        self.call_command("--no-input")
+
+        self.user.refresh_from_db()
+
+        self.assertEqual(
+            first=self.user.email, second=f"{self.user.pk}@auth.testserver.net"
+        )


### PR DESCRIPTION
## Description

### Added

- Management command to anonymize all user's email addresses in the database
  ```shell
  python manage.py tnnt_anonymize_emails
  ```
  This will replace each user's email address with `user_id@domain.tld` (e.g. `371@my.auth.com`)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
