### PR TITLE
[ADD] Workaround for `django-bootstrap5` error template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Section Order:
 
 ### Added
 
+- Workaround for `django-bootstrap5` error template until it is fixed upstream (https://github.com/zostera/django-bootstrap5/pull/767)
 - Bottom margin to DataTable filter wrappers
 - Bootstrap tooltips to `package_monitor` templates
 - Transition animation to overflow changes

--- a/tnnt_templates/templates/django_bootstrap5/field_errors.html
+++ b/tnnt_templates/templates/django_bootstrap5/field_errors.html
@@ -1,0 +1,7 @@
+{% if field_errors %}
+    <div id="{{ field.auto_id }}_error" class="invalid-feedback">
+        {% for text in field_errors %}
+            <div>{{ text }}</div>
+        {% endfor %}
+    </div>
+{% endif %}


### PR DESCRIPTION
## Description

### Added

- Workaround for `django-bootstrap5` error template until it is fixed upstream (https://github.com/zostera/django-bootstrap5/pull/767)

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
