### PR TITLE
[ADD] Workaround for `structuretimers` form template to use B%5 form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ Section Order:
 
 ### Added
 
-- Workaround for `django-bootstrap5` error template until it is fixed upstream (https://github.com/zostera/django-bootstrap5/pull/767)
+- Workaround for `structuretimers` form template to use Bootstrap5 form until fixed
+  and release upstream (https://gitlab.com/ErikKalkoken/aa-structuretimers/-/merge_requests/22)
+- Workaround for `django-bootstrap5` error template until it is fixed and released
+  upstream (https://github.com/zostera/django-bootstrap5/pull/767)
 - Bottom margin to DataTable filter wrappers
 - Bootstrap tooltips to `package_monitor` templates
 - Transition animation to overflow changes

--- a/tnnt_templates/templates/structuretimers/timer_edit.html
+++ b/tnnt_templates/templates/structuretimers/timer_edit.html
@@ -1,0 +1,56 @@
+{% extends "structuretimers/base.html" %}
+{% load django_bootstrap5 %}
+{% load static %}
+{% load i18n %}
+
+{% block content %}
+    <div class="row">
+        <div class="col col-lg-8">
+            <div class="card card-default">
+                <div class="card-body">
+                    {% if form.errors %}
+                        <p class="text-danger">
+                            <i class="fas fa-exclamation-triangle"></i>
+                            <strong> {% translate "Please correct the input errors below" %}</strong>
+                        </p>
+                    {% endif %}
+                    <form id="add-timer-form" class="form-signin" role="form" action="" method="POST">
+                        {% csrf_token %}
+                        {% bootstrap_form form %}
+                        <br>
+                        <p>
+                            <i class="fas fa-asterisk"></i> {% translate "required fields" %}
+                        </p>
+                        <button class="btn btn-primary" type="submit">
+                            {% block submit_button_text %}{% endblock %}
+                        </button>
+                        {% include 'structuretimers/partials/cancel_button.html' %}
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- share data with JS part -->
+    <div
+        id="dataExport"
+        data-select2SolarSystemsUrl="{% url 'structuretimers:select2_solar_systems' %}"
+        data-select2StructureTypesUrl="{% url 'structuretimers:select2_structure_types' %}">
+    </div>
+
+    {{ NIGHT_MODE|json_script:"night-mode-data" }}
+    {{ LANGUAGE_CODE|json_script:"language-code-data" }}
+{% endblock content %}
+
+{% block extra_css %}
+    <link href="{% static 'structuretimers/vendor/select2-4.1.0-beta.1/select2.min.css' %}" rel="stylesheet">
+    <link href="{% static 'structuretimers/vendor/select2-bootstrap-theme-0.1.0-beta.10/select2-bootstrap.min.css' %}" rel="stylesheet">
+    {% include "bundles/jquery-datetimepicker-css.html" %}
+    <link href="{% static 'structuretimers/css/timer_edit.css' %}" rel="stylesheet">
+{% endblock extra_css %}
+
+{% block extra_javascript %}
+    <script type="application/javascript" src="{% static 'structuretimers/vendor/select2-4.1.0-beta.1/select2.min.js' %}"></script>
+    {% include "bundles/jquery-datetimepicker-js.html" %}
+    <script type="text/javascript" src="{% static 'structuretimers/js/timer_edit.js' %}"></script>
+{% endblock extra_javascript %}


### PR DESCRIPTION
## Description

### Added

- Workaround for `structuretimers` form template to use Bootstrap5 form until fixed
  and release upstream (https://gitlab.com/ErikKalkoken/aa-structuretimers/-/merge_requests/22)

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
