### PR TITLE
[RELEASE] v3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [3.12.0] - 2025-09-05
+
 ### Added
 
 - Workaround for `structuretimers` form template to use Bootstrap5 form until fixed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ______________________________________________________________________
 ## Install<a name="install"></a>
 
 ```shell
-pip install tnnt-templates==3.11.1
+pip install tnnt-templates==3.12.0
 ```
 
 In `local.py` right after `INSTALLED_APPS`:

--- a/tnnt_templates/__init__.py
+++ b/tnnt_templates/__init__.py
@@ -2,5 +2,5 @@
 TN-NT Templates init
 """
 
-__version__ = "3.11.1"
+__version__ = "3.12.0"
 __title__ = "Terra Nanotech Alliance Auth Template Overrides"


### PR DESCRIPTION
## [3.12.0] - 2025-09-05

### Added

- Workaround for `structuretimers` form template to use Bootstrap5 form until fixed and release upstream (https://gitlab.com/ErikKalkoken/aa-structuretimers/-/merge_requests/22)
- Workaround for `django-bootstrap5` error template until it is fixed and released upstream (https://github.com/zostera/django-bootstrap5/pull/767)
- Bottom margin to DataTable filter wrappers
- Bootstrap tooltips to `package_monitor` templates
- Transition animation to overflow changes
- Overflow detection and monitoring
- Border radius to active menu items

### Fixed

- HighlightJS copy code button size and position
- Some transparencies
