### PR TITLE
[RELEASE] v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [5.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -1819,6 +1821,7 @@ run it with any version prior!**
 [3.9.1]: https://github.com/terra-nanotech/tn-nt-auth-templates/compare/v3.9.0...v3.9.1 "v3.9.1"
 [4.0.0]: https://github.com/terra-nanotech/tn-nt-auth-templates/compare/v3.15.3...v4.0.0 "v4.0.0"
 [4.0.1]: https://github.com/terra-nanotech/tn-nt-auth-templates/compare/v4.0.0...v4.0.1 "v4.0.1"
-[in development]: https://github.com/terra-nanotech/tn-nt-auth-templates/compare/v4.0.1...HEAD "In Development"
+[5.0.0]: https://github.com/terra-nanotech/tn-nt-auth-templates/compare/v4.0.1...v5.0.0 "v5.0.0"
+[in development]: https://github.com/terra-nanotech/tn-nt-auth-templates/compare/v5.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ______________________________________________________________________
 ## Install<a name="install"></a>
 
 ```shell
-pip install tnnt-templates==4.0.1
+pip install tnnt-templates==5.0.0
 ```
 
 In `local.py` right after `INSTALLED_APPS`:

--- a/tnnt_templates/__init__.py
+++ b/tnnt_templates/__init__.py
@@ -2,5 +2,5 @@
 TN-NT Templates init
 """
 
-__version__ = "4.0.1"
+__version__ = "5.0.0"
 __title__ = "Terra Nanotech Alliance Auth Template Overrides"


### PR DESCRIPTION
## [5.0.0] - 2026-06-07

> [!IMPORTANT]
>
> **This version needs Alliance Auth v5!**
>
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Fixed

- AA Forum widget SVG color

### Changed

- Force community apps CSS overrides to be explicit
- Background to match Cradle of War expansion